### PR TITLE
fix: hidden snapping circle on "draw" line deactivation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Depending on whether you are using, Browser(`purejs`) ES Modules (`import`) or C
 
 - **For ES Modules (`import`)**:
   ```javascript
-  import MapboxSnap from 'mapbox-gl-snap/dist/cjs/MapboxSnap';
+  import MapboxSnap from 'mapbox-gl-snap/dist/esm/MapboxSnap';
   ```
 
 - **For CommonJS (`require`)**:
   ```javascript
-  const MapboxSnap = require('mapbox-gl-snap/dist/esm/MapboxSnap');
+  const MapboxSnap = require('mapbox-gl-snap/dist/cjs/MapboxSnap');
   ```
 
 ## Features

--- a/dist/cjs/MapboxSnap.js
+++ b/dist/cjs/MapboxSnap.js
@@ -146,6 +146,12 @@ var MapboxSnap = /** @class */ (function () {
     MapboxSnap.prototype.setStatus = function (s) {
         this.status = s;
     };
+    MapboxSnap.prototype.setMapData = function (featureCollection) {
+        var source = this.map.getSource('snap-helper-circle');
+        if (source) {
+            source.setData(featureCollection);
+        }
+    };
     MapboxSnap.prototype.snapToClosestPoint = function (e) {
         if (this.status) {
             var point = e.point;
@@ -166,10 +172,7 @@ var MapboxSnap = /** @class */ (function () {
                 this.snapCoords = [];
             }
             var circleGeoJSON = (0, helpers_1.featureCollection)(circle == false ? [] : [circle]);
-            var source = this.map.getSource('snap-helper-circle');
-            if (source) {
-                source.setData(circleGeoJSON);
-            }
+            this.setMapData(circleGeoJSON);
         }
     };
     MapboxSnap.prototype.addEvents = function () {
@@ -197,10 +200,8 @@ var MapboxSnap = /** @class */ (function () {
                 _this.status = true;
             }
             else {
-                setTimeout(function () {
-                    _this.changeSnappedPoints();
-                }, 100);
                 _this.status = false;
+                _this.setMapData(featureCollection([]));
             }
         });
         this.map.on('draw.modechange', function (e) {

--- a/dist/esm/MapboxSnap.js
+++ b/dist/esm/MapboxSnap.js
@@ -141,6 +141,12 @@ var MapboxSnap = /** @class */ (function () {
     MapboxSnap.prototype.setStatus = function (s) {
         this.status = s;
     };
+    MapboxSnap.prototype.setMapData = function (featureCollection) {
+        var source = this.map.getSource('snap-helper-circle');
+        if (source) {
+            source.setData(featureCollection);
+        }
+    };
     MapboxSnap.prototype.snapToClosestPoint = function (e) {
         if (this.status) {
             var point = e.point;
@@ -161,10 +167,7 @@ var MapboxSnap = /** @class */ (function () {
                 this.snapCoords = [];
             }
             var circleGeoJSON = featureCollection(circle == false ? [] : [circle]);
-            var source = this.map.getSource('snap-helper-circle');
-            if (source) {
-                source.setData(circleGeoJSON);
-            }
+            this.setMapData(circleGeoJSON);
         }
     };
     MapboxSnap.prototype.addEvents = function () {
@@ -192,10 +195,8 @@ var MapboxSnap = /** @class */ (function () {
                 _this.status = true;
             }
             else {
-                setTimeout(function () {
-                    _this.changeSnappedPoints();
-                }, 100);
                 _this.status = false;
+                _this.setMapData(featureCollection([]));
             }
         });
         this.map.on('draw.modechange', function (e) {

--- a/dist/purejs/mapbox-gl-snap.js
+++ b/dist/purejs/mapbox-gl-snap.js
@@ -5508,6 +5508,12 @@
         MapboxSnap.prototype.setStatus = function (s) {
             this.status = s;
         };
+        MapboxSnap.prototype.setMapData = function (featureCollection) {
+            var source = this.map.getSource('snap-helper-circle');
+            if (source) {
+                source.setData(featureCollection);
+            }
+        };
         MapboxSnap.prototype.snapToClosestPoint = function (e) {
             if (this.status) {
                 var point = e.point;
@@ -5528,10 +5534,7 @@
                     this.snapCoords = [];
                 }
                 var circleGeoJSON = featureCollection$2(circle$1 == false ? [] : [circle$1]);
-                var source = this.map.getSource('snap-helper-circle');
-                if (source) {
-                    source.setData(circleGeoJSON);
-                }
+                this.setMapData(circleGeoJSON);
             }
         };
         MapboxSnap.prototype.addEvents = function () {
@@ -5559,10 +5562,8 @@
                     _this.status = true;
                 }
                 else {
-                    setTimeout(function () {
-                        _this.changeSnappedPoints();
-                    }, 100);
                     _this.status = false;
+                    _this.setMapData(featureCollection([]));
                 }
             });
             this.map.on('draw.modechange', function (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mapbox-gl-snap",
-    "version": "1.0.9",
+    "version": "1.1.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mapbox-gl-snap",
-            "version": "1.0.9",
+            "version": "1.1.8",
             "license": "MIT",
             "dependencies": {
                 "@mapbox/mapbox-gl-draw": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mapbox-gl-snap",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "A utility to snap points to vertices, edges, or midpoints on a Mapbox GL JS.",
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.esm.js",


### PR DESCRIPTION
Hello, this is a fix of the issue https://github.com/gislayer/mapbox-gl-snap/issues/3

1. Removed call in 'draw.selectionchange' event handler, because it prevents snap circle to be hidden if drawn line is still visible.
2. Added `setMapData` method to remove code duplication to add data on a map.
3. Corrected (probably not corresponding) imports in README.md.